### PR TITLE
Config units

### DIFF
--- a/aict_tools/configuration.py
+++ b/aict_tools/configuration.py
@@ -160,6 +160,7 @@ class DispConfig:
         'cog_x_column',
         'cog_y_column',
         'delta_column',
+        'delta_unit',
         'log_target',
         'project_disp',
         'coordinate_transformation',
@@ -212,6 +213,7 @@ class DispConfig:
         self.cog_x_column = model_config.get('cog_x_column', 'cog_x')
         self.cog_y_column = model_config.get('cog_y_column', 'cog_y')
         self.delta_column = model_config.get('delta_column', 'delta')
+        self.delta_unit = u.Unit(model_config.get('delta_unit', 'deg'))
 
         cols = {
             self.cog_x_column,

--- a/aict_tools/configuration.py
+++ b/aict_tools/configuration.py
@@ -96,6 +96,7 @@ class AICTConfig:
         'energy',
         'separator',
         'has_multiple_telescopes',
+        'energy_unit',
     )
 
     @classmethod
@@ -122,6 +123,7 @@ class AICTConfig:
             self.array_events_key = None
             self.array_event_id_column = None
 
+        self.energy_unit = u.Unit(config.get('energy_unit', 'GeV'))
         self.seed = config.get('seed', 0)
         np.random.seed(self.seed)
 

--- a/aict_tools/configuration.py
+++ b/aict_tools/configuration.py
@@ -1,3 +1,4 @@
+import astropy.units as u
 from ruamel.yaml import YAML
 from collections import namedtuple
 from .features import find_used_source_features
@@ -95,6 +96,7 @@ class AICTConfig:
         'energy',
         'separator',
         'has_multiple_telescopes',
+        'energy_unit',
     )
 
     @classmethod
@@ -121,6 +123,7 @@ class AICTConfig:
             self.array_events_key = None
             self.array_event_id_column = None
 
+        self.energy_unit = u.Unit(config.get('energy_unit', 'GeV'))
         self.seed = config.get('seed', 0)
         np.random.seed(self.seed)
 
@@ -146,9 +149,13 @@ class DispConfig:
         'columns_to_read_apply',
         'columns_to_read_train',
         'source_az_column',
+        'source_az_unit',
         'source_zd_column',
+        'source_zd_unit',
         'pointing_az_column',
+        'pointing_az_unit',
         'pointing_zd_column',
+        'pointing_zd_unit',
         'focal_length_column',
         'cog_x_column',
         'cog_y_column',
@@ -193,9 +200,14 @@ class DispConfig:
 
         self.source_az_column = model_config.get('source_az_column', 'source_position_az')
         self.source_zd_column = model_config.get('source_zd_column', 'source_position_zd')
+        self.source_az_unit = u.Unit(model_config.get('source_az_unit', 'deg'))
+        self.source_zd_unit = u.Unit(model_config.get('source_zd_unit', 'deg'))
 
         self.pointing_az_column = model_config.get('pointing_az_column', 'pointing_position_az')
         self.pointing_zd_column = model_config.get('pointing_zd_column', 'pointing_position_zd')
+        self.pointing_az_unit = u.Unit(model_config.get('pointing_zd_unit', 'deg'))
+        self.pointing_zd_unit = u.Unit(model_config.get('pointing_zd_unit', 'deg'))
+
         self.focal_length_column = model_config.get('focal_length_column', 'focal_length')
         self.cog_x_column = model_config.get('cog_x_column', 'cog_x')
         self.cog_y_column = model_config.get('cog_y_column', 'cog_y')

--- a/aict_tools/configuration.py
+++ b/aict_tools/configuration.py
@@ -96,7 +96,6 @@ class AICTConfig:
         'energy',
         'separator',
         'has_multiple_telescopes',
-        'energy_unit',
     )
 
     @classmethod
@@ -123,7 +122,6 @@ class AICTConfig:
             self.array_events_key = None
             self.array_event_id_column = None
 
-        self.energy_unit = u.Unit(config.get('energy_unit', 'GeV'))
         self.seed = config.get('seed', 0)
         np.random.seed(self.seed)
 

--- a/aict_tools/configuration.py
+++ b/aict_tools/configuration.py
@@ -157,6 +157,7 @@ class DispConfig:
         'pointing_zd_column',
         'pointing_zd_unit',
         'focal_length_column',
+        'focal_length_unit',
         'cog_x_column',
         'cog_y_column',
         'delta_column',
@@ -210,6 +211,8 @@ class DispConfig:
         self.pointing_zd_unit = u.Unit(model_config.get('pointing_zd_unit', 'deg'))
 
         self.focal_length_column = model_config.get('focal_length_column', 'focal_length')
+        self.focal_length_unit = u.Unit(model_config.get('focal_length', 'm'))
+
         self.cog_x_column = model_config.get('cog_x_column', 'cog_x')
         self.cog_y_column = model_config.get('cog_y_column', 'cog_y')
         self.delta_column = model_config.get('delta_column', 'delta')

--- a/aict_tools/plotting.py
+++ b/aict_tools/plotting.py
@@ -8,13 +8,13 @@ from sklearn import metrics
 from sklearn.calibration import CalibratedClassifierCV
 
 
-def plot_regressor_confusion(performace_df, log_xy=True, log_z=True, ax=None, label_column='label', prediction_column='label_prediction'):
+def plot_regressor_confusion(performance_df, log_xy=True, log_z=True, ax=None, label_column='label', prediction_column='label_prediction'):
 
     ax = ax or plt.gca()
 
-    label = performace_df[label_column].copy()
+    label = performance_df[label_column].copy()
 
-    prediction = performace_df[prediction_column].copy()
+    prediction = performance_df[prediction_column].copy()
 
     if log_xy is True:
         label = np.log10(label)
@@ -46,8 +46,8 @@ def plot_regressor_confusion(performace_df, log_xy=True, log_z=True, ax=None, la
     return ax
 
 
-def plot_bias_resolution(performace_df, bins=10, ax=None, label_column='label', prediction_column='label_prediction'):
-    df = performace_df.copy()
+def plot_bias_resolution(performance_df, bins=10, ax=None, label_column='label', prediction_column='label_prediction'):
+    df = performance_df.copy()
 
     ax = ax or plt.gca()
 
@@ -93,7 +93,7 @@ def plot_bias_resolution(performace_df, bins=10, ax=None, label_column='label', 
     return ax
 
 
-def plot_roc(performace_df, model, ax=None, label_column='label', score_column='probabilities'):
+def plot_roc(performance_df, model, ax=None, label_column='label', score_column='probabilities'):
 
     ax = ax or plt.gca()
 
@@ -104,8 +104,8 @@ def plot_roc(performace_df, model, ax=None, label_column='label', score_column='
 
     roc_aucs = []
 
-    mean_fpr, mean_tpr, _ = metrics.roc_curve(performace_df[label_column], performace_df[score_column])
-    for it, df in performace_df.groupby('cv_fold'):
+    mean_fpr, mean_tpr, _ = metrics.roc_curve(performance_df[label_column], performance_df[score_column])
+    for it, df in performance_df.groupby('cv_fold'):
 
         fpr, tpr, _ = metrics.roc_curve(df[label_column], df[score_column])
 
@@ -132,7 +132,7 @@ def plot_roc(performace_df, model, ax=None, label_column='label', score_column='
     return ax
 
 
-def plot_probabilities(performace_df, model, ax=None, xlabel='score', classnames={0:'Proton', 1:'Gamma'}, label_column='label', score_column='probabilities'):
+def plot_probabilities(performance_df, model, ax=None, xlabel='score', classnames={0:'Proton', 1:'Gamma'}, label_column='label', score_column='probabilities'):
 
     ax = ax or plt.gca()
 
@@ -140,10 +140,10 @@ def plot_probabilities(performace_df, model, ax=None, xlabel='score', classnames
         model = model.base_estimator
 
     n_bins = (model.n_estimators + 1) if hasattr(model, 'n_estimators') else 100
-    bin_edges = np.linspace(performace_df[score_column].min(), performace_df[score_column].max(), n_bins + 1)
+    bin_edges = np.linspace(performance_df[score_column].min(), performance_df[score_column].max(), n_bins + 1)
 
 
-    for label, df in performace_df.groupby(label_column):
+    for label, df in performance_df.groupby(label_column):
         ax.hist(
             df[score_column],
             bins=bin_edges, label=classnames[label], histtype='step',
@@ -154,7 +154,7 @@ def plot_probabilities(performace_df, model, ax=None, xlabel='score', classnames
     ax.figure.tight_layout()
 
 
-def plot_precision_recall(performace_df, model, ax=None, beta=0.1):
+def plot_precision_recall(performance_df, model, ax=None, beta=0.1):
 
     ax = ax or plt.gca()
 
@@ -173,8 +173,8 @@ def plot_precision_recall(performace_df, model, ax=None, beta=0.1):
     ax.axhline(1, color='lightgray')
     for threshold in thresholds:
 
-        prediction = (performace_df.probabilities.values >= threshold).astype('int')
-        label = performace_df.label.values
+        prediction = (performance_df.probabilities.values >= threshold).astype('int')
+        label = performance_df.label.values
 
         precision.append(metrics.precision_score(label, prediction))
         recall.append(metrics.recall_score(label, prediction))

--- a/aict_tools/plotting.py
+++ b/aict_tools/plotting.py
@@ -8,7 +8,15 @@ from sklearn import metrics
 from sklearn.calibration import CalibratedClassifierCV
 
 
-def plot_regressor_confusion(performance_df, log_xy=True, log_z=True, ax=None, label_column='label', prediction_column='label_prediction'):
+def plot_regressor_confusion(
+        performance_df,
+        log_xy=True,
+        log_z=True,
+        ax=None,
+        label_column='label',
+        prediction_column='label_prediction',
+        energy_unit='GeV'
+        ):
 
     ax = ax or plt.gca()
 
@@ -37,16 +45,27 @@ def plot_regressor_confusion(performance_df, log_xy=True, log_z=True, ax=None, l
     ax.figure.colorbar(img, ax=ax)
 
     if log_xy is True:
-        ax.set_xlabel(r'$\log_{10}(E_{\mathrm{MC}} \,\, / \,\, \mathrm{GeV})$')
-        ax.set_ylabel(r'$\log_{10}(E_{\mathrm{Est}} \,\, / \,\, \mathrm{GeV})$')
+        ax.set_xlabel(
+                rf'$\log_{10}(E_{{\mathrm{{MC}}}} \,\, / \,\, \mathrm{{{energy_unit}}})$')
+        ax.set_ylabel(
+                rf'$\log_{10}(E_{{\mathrm{{Est}}}} \,\, / \,\, \mathrm{{{energy_unit}}})$')
     else:
-        ax.set_xlabel(r'$E_{\mathrm{MC}} \,\, / \,\, \mathrm{GeV}$')
-        ax.set_ylabel(r'$E_{\mathrm{Est}} \,\, / \,\, \mathrm{GeV}$')
+        ax.set_xlabel(
+                rf'$E_{{\mathrm{{MC}}}} \,\, / \,\, \mathrm{{{energy_unit}}}$')
+        ax.set_ylabel(
+                rf'$E_{{\mathrm{{Est}}}} \,\, / \,\, \mathrm{{{energy_unit}}}$')
 
     return ax
 
 
-def plot_bias_resolution(performance_df, bins=10, ax=None, label_column='label', prediction_column='label_prediction'):
+def plot_bias_resolution(
+        performance_df,
+        bins=10,
+        ax=None,
+        label_column='label',
+        prediction_column='label_prediction',
+        energy_unit='GeV'
+        ):
     df = performance_df.copy()
 
     ax = ax or plt.gca()
@@ -88,12 +107,19 @@ def plot_bias_resolution(performance_df, bins=10, ax=None, label_column='label',
         )
     ax.legend()
     ax.set_xscale('log')
-    ax.set_xlabel(r'$\log_{10}(E_{\mathrm{true}} \,\, / \,\, \mathrm{GeV})$')
+    ax.set_xlabel(
+            rf'$\log_{10}(E_{{\mathrm{{MC}}}} \,\, / \,\, \mathrm{{{energy_unit}}})$')
 
     return ax
 
 
-def plot_roc(performance_df, model, ax=None, label_column='label', score_column='probabilities'):
+def plot_roc(
+        performance_df,
+        model,
+        ax=None,
+        label_column='label',
+        score_column='probabilities'
+        ):
 
     ax = ax or plt.gca()
 
@@ -104,7 +130,8 @@ def plot_roc(performance_df, model, ax=None, label_column='label', score_column=
 
     roc_aucs = []
 
-    mean_fpr, mean_tpr, _ = metrics.roc_curve(performance_df[label_column], performance_df[score_column])
+    mean_fpr, mean_tpr, _ = metrics.roc_curve(
+            performance_df[label_column], performance_df[score_column])
     for it, df in performance_df.groupby('cv_fold'):
 
         fpr, tpr, _ = metrics.roc_curve(df[label_column], df[score_column])
@@ -132,7 +159,15 @@ def plot_roc(performance_df, model, ax=None, label_column='label', score_column=
     return ax
 
 
-def plot_probabilities(performance_df, model, ax=None, xlabel='score', classnames={0:'Proton', 1:'Gamma'}, label_column='label', score_column='probabilities'):
+def plot_probabilities(
+        performance_df,
+        model,
+        ax=None,
+        xlabel='score',
+        classnames={0: 'Proton', 1: 'Gamma'},
+        label_column='label',
+        score_column='probabilities'
+        ):
 
     ax = ax or plt.gca()
 
@@ -140,8 +175,11 @@ def plot_probabilities(performance_df, model, ax=None, xlabel='score', classname
         model = model.base_estimator
 
     n_bins = (model.n_estimators + 1) if hasattr(model, 'n_estimators') else 100
-    bin_edges = np.linspace(performance_df[score_column].min(), performance_df[score_column].max(), n_bins + 1)
-
+    bin_edges = np.linspace(
+            performance_df[score_column].min(),
+            performance_df[score_column].max(),
+            n_bins + 1
+        )
 
     for label, df in performance_df.groupby(label_column):
         ax.hist(

--- a/aict_tools/plotting.py
+++ b/aict_tools/plotting.py
@@ -254,7 +254,6 @@ def plot_true_delta_delta(data_df, model_config, ax=None):
             zd_pointing=df[model_config.pointing_zd_column],
             focal_length=df[model_config.focal_length_column],
         )
-        df[model_config.delta_column] = np.deg2rad(df[model_config.delta_column])
     elif model_config.coordinate_transformation == 'FACT':
         from fact.coordinates.utils import horizontal_to_camera
         source_x, source_y = horizontal_to_camera(

--- a/aict_tools/plotting.py
+++ b/aict_tools/plotting.py
@@ -16,7 +16,7 @@ def plot_regressor_confusion(
         label_column='label',
         prediction_column='label_prediction',
         energy_unit='GeV'
-        ):
+):
 
     ax = ax or plt.gca()
 
@@ -46,14 +46,18 @@ def plot_regressor_confusion(
 
     if log_xy is True:
         ax.set_xlabel(
-                rf'$\log_{10}(E_{{\mathrm{{MC}}}} \,\, / \,\, \mathrm{{{energy_unit}}})$')
+                rf'$\log_{10}(E_{{\mathrm{{MC}}}} \,\, / \,\, \mathrm{{{energy_unit}}})$'
+        )
         ax.set_ylabel(
-                rf'$\log_{10}(E_{{\mathrm{{Est}}}} \,\, / \,\, \mathrm{{{energy_unit}}})$')
+                rf'$\log_{10}(E_{{\mathrm{{Est}}}} \,\, / \,\, \mathrm{{{energy_unit}}})$'
+        )
     else:
         ax.set_xlabel(
-                rf'$E_{{\mathrm{{MC}}}} \,\, / \,\, \mathrm{{{energy_unit}}}$')
+                rf'$E_{{\mathrm{{MC}}}} \,\, / \,\, \mathrm{{{energy_unit}}}$'
+        )
         ax.set_ylabel(
-                rf'$E_{{\mathrm{{Est}}}} \,\, / \,\, \mathrm{{{energy_unit}}}$')
+                rf'$E_{{\mathrm{{Est}}}} \,\, / \,\, \mathrm{{{energy_unit}}}$'
+        )
 
     return ax
 
@@ -65,7 +69,7 @@ def plot_bias_resolution(
         label_column='label',
         prediction_column='label_prediction',
         energy_unit='GeV'
-        ):
+):
     df = performance_df.copy()
 
     ax = ax or plt.gca()
@@ -108,7 +112,8 @@ def plot_bias_resolution(
     ax.legend()
     ax.set_xscale('log')
     ax.set_xlabel(
-            rf'$\log_{10}(E_{{\mathrm{{MC}}}} \,\, / \,\, \mathrm{{{energy_unit}}})$')
+            rf'$\log_{10}(E_{{\mathrm{{MC}}}} \,\, / \,\, \mathrm{{{energy_unit}}})$'
+    )
 
     return ax
 
@@ -119,7 +124,7 @@ def plot_roc(
         ax=None,
         label_column='label',
         score_column='probabilities'
-        ):
+):
 
     ax = ax or plt.gca()
 
@@ -167,7 +172,7 @@ def plot_probabilities(
         classnames={0: 'Proton', 1: 'Gamma'},
         label_column='label',
         score_column='probabilities'
-        ):
+):
 
     ax = ax or plt.gca()
 
@@ -179,7 +184,7 @@ def plot_probabilities(
             performance_df[score_column].min(),
             performance_df[score_column].max(),
             n_bins + 1
-        )
+    )
 
     for label, df in performance_df.groupby(label_column):
         ax.hist(

--- a/aict_tools/plotting.py
+++ b/aict_tools/plotting.py
@@ -136,7 +136,9 @@ def plot_roc(
     roc_aucs = []
 
     mean_fpr, mean_tpr, _ = metrics.roc_curve(
-            performance_df[label_column], performance_df[score_column])
+        performance_df[label_column],
+        performance_df[score_column],
+    )
     for it, df in performance_df.groupby('cv_fold'):
 
         fpr, tpr, _ = metrics.roc_curve(df[label_column], df[score_column])

--- a/aict_tools/plotting.py
+++ b/aict_tools/plotting.py
@@ -183,9 +183,9 @@ def plot_scores(
 
     n_bins = (model.n_estimators + 1) if hasattr(model, 'n_estimators') else 100
     bin_edges = np.linspace(
-            performance_df[score_column].min(),
-            performance_df[score_column].max(),
-            n_bins + 1
+        performance_df[score_column].min(),
+        performance_df[score_column].max(),
+        n_bins + 1,
     )
     for label, df in performance_df.groupby(label_column):
         ax.hist(

--- a/aict_tools/preprocessing.py
+++ b/aict_tools/preprocessing.py
@@ -79,11 +79,9 @@ def calc_true_disp(source_x, source_y, cog_x, cog_y, delta, project_disp=False):
     return abs_disp, sign_disp
 
 
-def sanitize_angle_units(df, model_config):
+def convert_units(df, model_config):
     '''
-    Transforms the coordinates to the desired units.
-    This is done in order to avoid deg <-> rad units as
-    have occured frequently when working with CTA data.
+    Transforms the columns to the desired units.
 
     Parameters:
     -----------

--- a/aict_tools/preprocessing.py
+++ b/aict_tools/preprocessing.py
@@ -99,6 +99,7 @@ def sanitize_angle_units(df, model_config):
     '''
     coordinate_units = (
         (model_config.delta_column, model_config.delta_unit, 'rad'),
+        (model_config.focal_length_column, model_config.focal_length_unit, 'm'),
         (model_config.source_az_column, model_config.source_az_unit, 'deg'),
         (model_config.source_zd_column, model_config.source_zd_unit, 'deg'),
         (model_config.pointing_az_column, model_config.pointing_az_unit, 'deg'),
@@ -106,7 +107,10 @@ def sanitize_angle_units(df, model_config):
     )
     for column, unit, expected_unit in coordinate_units:
         if unit != expected_unit:
-            converted_values = u.Quantity(df[column], unit).to(expected_unit).value
+            converted_values = u.Quantity(
+                    df[column].to_numpy(),
+                    unit,
+                    copy=False).to_value(expected_unit)
             df[column] = converted_values
 
     return df

--- a/aict_tools/preprocessing.py
+++ b/aict_tools/preprocessing.py
@@ -104,12 +104,11 @@ def convert_units(df, model_config):
         (model_config.pointing_zd_column, model_config.pointing_zd_unit, 'deg'),
     )
     for column, unit, expected_unit in coordinate_units:
-        if unit != expected_unit:
-            converted_values = u.Quantity(
-                    df[column].to_numpy(),
-                    unit,
-                    copy=False,
+        if column in df.columns and unit != expected_unit:
+            df[column] = u.Quantity(
+                df[column].to_numpy(),
+                unit,
+                copy=False,
             ).to_value(expected_unit)
-            df[column] = converted_values
 
     return df

--- a/aict_tools/preprocessing.py
+++ b/aict_tools/preprocessing.py
@@ -110,7 +110,8 @@ def sanitize_angle_units(df, model_config):
             converted_values = u.Quantity(
                     df[column].to_numpy(),
                     unit,
-                    copy=False).to_value(expected_unit)
+                    copy=False,
+                ).to_value(expected_unit)
             df[column] = converted_values
 
     return df

--- a/aict_tools/preprocessing.py
+++ b/aict_tools/preprocessing.py
@@ -111,7 +111,7 @@ def sanitize_angle_units(df, model_config):
                     df[column].to_numpy(),
                     unit,
                     copy=False,
-                ).to_value(expected_unit)
+            ).to_value(expected_unit)
             df[column] = converted_values
 
     return df

--- a/aict_tools/scripts/plot_disp_performance.py
+++ b/aict_tools/scripts/plot_disp_performance.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import joblib
 import fact.io
 
-from ..preprocessing import sanitize_angle_units
+from ..preprocessing import convert_units
 from ..configuration import AICTConfig
 from ..plotting import (
     plot_roc,
@@ -66,7 +66,7 @@ def main(configuration_path, performance_path, data_path, disp_model_path, sign_
     log.info('Loading sign model')
     sign_model = joblib.load(sign_model_path)
 
-    df_data = sanitize_angle_units(df, model_config)
+    df_data = convert_units(df, model_config)
 
     figures = []
 

--- a/aict_tools/scripts/plot_disp_performance.py
+++ b/aict_tools/scripts/plot_disp_performance.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 import joblib
 import fact.io
 
+from ..preprocessing import sanitize_angle_units
 from ..configuration import AICTConfig
 from ..plotting import (
     plot_roc,
@@ -30,7 +31,7 @@ else:
 @click.option('-k', '--key', help='HDF5 key for hdf5 for performance_path', default='data')
 @click.option('-k_data', '--key_data', help='HDF5 key for hdf5 for data_path', default='events')
 def main(configuration_path, performance_path, data_path, disp_model_path, sign_model_path, output, key, key_data):
-    ''' Createsome performance evaluation plots for the disp model'''
+    ''' Create some performance evaluation plots for the disp model'''
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger()
 
@@ -62,6 +63,8 @@ def main(configuration_path, performance_path, data_path, disp_model_path, sign_
 
     log.info('Loading sign model')
     sign_model = joblib.load(sign_model_path)
+
+    df_data = sanitize_angle_units(df, model_config)
 
     figures = []
 

--- a/aict_tools/scripts/plot_disp_performance.py
+++ b/aict_tools/scripts/plot_disp_performance.py
@@ -66,7 +66,7 @@ def main(configuration_path, performance_path, data_path, disp_model_path, sign_
     log.info('Loading sign model')
     sign_model = joblib.load(sign_model_path)
 
-    df_data = convert_units(df, model_config)
+    df_data = convert_units(df_data, model_config)
 
     figures = []
 

--- a/aict_tools/scripts/plot_regressor_performance.py
+++ b/aict_tools/scripts/plot_regressor_performance.py
@@ -35,26 +35,29 @@ def main(configuration_path, performance_path, model_path, output, key):
     log.info('Loading model')
     model = joblib.load(model_path)
 
-    model_config = AICTConfig.from_yaml(configuration_path).energy
+    config = AICTConfig.from_yaml(configuration_path)
+    model_config = config.energy
+    energy_unit = config.energy_unit
+
     figures = []
 
     # Plot confusion
     figures.append(plt.figure())
     ax = figures[-1].add_subplot(1, 1, 1)
     ax.set_title('Reconstructed vs. True Energy (log color scale)')
-    plot_regressor_confusion(df, ax=ax)
+    plot_regressor_confusion(df, ax=ax, energy_unit=energy_unit)
 
     # Plot confusion
     figures.append(plt.figure())
     ax = figures[-1].add_subplot(1, 1, 1)
     ax.set_title('Reconstructed vs. True Energy (linear color scale)')
-    plot_regressor_confusion(df, log_z=False, ax=ax)
+    plot_regressor_confusion(df, log_z=False, ax=ax, energy_unit=energy_unit)
 
     # Plot bias/resolution
     figures.append(plt.figure())
     ax = figures[-1].add_subplot(1, 1, 1)
     ax.set_title('Bias and Resolution')
-    plot_bias_resolution(df, bins=15, ax=ax)
+    plot_bias_resolution(df, bins=15, ax=ax, energy_unit=energy_unit)
 
     if hasattr(model, 'feature_importances_'):
         # Plot feature importances

--- a/aict_tools/scripts/train_disp_regressor.py
+++ b/aict_tools/scripts/train_disp_regressor.py
@@ -8,7 +8,7 @@ import numpy as np
 from fact.io import write_data
 from fact.coordinates.utils import horizontal_to_camera
 from ..io import save_model, read_telescope_data
-from ..preprocessing import convert_to_float32, calc_true_disp, sanitize_angle_units
+from ..preprocessing import convert_to_float32, calc_true_disp, convert_units
 from ..feature_generation import feature_generation
 from ..configuration import AICTConfig
 from ..logging import setup_logging
@@ -68,7 +68,7 @@ def main(configuration_path, signal_path, predictions_path, disp_model_path, sig
         model_config.coordinate_transformation
     )
 
-    df = sanitize_angle_units(df, model_config)
+    df = convert_units(df, model_config)
 
     if model_config.coordinate_transformation == 'CTA':
         from ..cta_helpers import horizontal_to_camera_cta_simtel

--- a/aict_tools/scripts/train_disp_regressor.py
+++ b/aict_tools/scripts/train_disp_regressor.py
@@ -8,7 +8,7 @@ import numpy as np
 from fact.io import write_data
 from fact.coordinates.utils import horizontal_to_camera
 from ..io import save_model, read_telescope_data
-from ..preprocessing import convert_to_float32, calc_true_disp
+from ..preprocessing import convert_to_float32, calc_true_disp, sanitize_angle_units
 from ..feature_generation import feature_generation
 from ..configuration import AICTConfig
 from ..logging import setup_logging
@@ -67,6 +67,9 @@ def main(configuration_path, signal_path, predictions_path, disp_model_path, sig
         'Using coordinate transformations for %s',
         model_config.coordinate_transformation
     )
+
+    df = sanitize_angle_units(df, model_config)
+
     if model_config.coordinate_transformation == 'CTA':
         from ..cta_helpers import horizontal_to_camera_cta_simtel
         source_x, source_y = horizontal_to_camera_cta_simtel(
@@ -76,8 +79,6 @@ def main(configuration_path, signal_path, predictions_path, disp_model_path, sig
             zd_pointing=df[model_config.pointing_zd_column],
             focal_length=df[model_config.focal_length_column],
         )
-        # cta preprocessing uses deg instead of rad
-        df[model_config.delta_column] = np.deg2rad(df[model_config.delta_column])
     elif model_config.coordinate_transformation == 'FACT':
         source_x, source_y = horizontal_to_camera(
             az=df[model_config.source_az_column],
@@ -138,7 +139,7 @@ def main(configuration_path, signal_path, predictions_path, disp_model_path, sig
             cv_disp_prediction = np.exp(cv_disp_prediction)
 
         sign_classifier.fit(cv_x_train, cv_sign_train)
-        cv_sign_score = 2 * sign_classifier.predict_proba(cv_x_test)[:, 1] -1
+        cv_sign_score = 2 * sign_classifier.predict_proba(cv_x_test)[:, 1] - 1
         cv_sign_prediction = np.where(cv_sign_score < 0, -1.0, 1.0)
 
         scores_disp.append(metrics.r2_score(cv_disp_test, cv_disp_prediction))

--- a/examples/config_source_cta.yaml
+++ b/examples/config_source_cta.yaml
@@ -38,7 +38,8 @@ disp:
   pointing_zd_column: pointing_altitude ###offset 90°
   cog_x_column: x  ## added
   cog_y_column: y  ## added
-  delta_column: psi ##????
+  delta_column: psi
+  delta_unit: deg ## cta preprocessing yields deg, we need to convert to rad
   array_event_column: array_event_id
 
 

--- a/examples/full_config.yaml
+++ b/examples/full_config.yaml
@@ -4,6 +4,7 @@ seed: 0
 # define th number of cross validations to perform
 n_cross_validations: 5
 
+energy_unit: GeV
 
 # Define the name of the column that contains the name of the telescope in case you're working
 # with mulitple telescopes and telescope types
@@ -126,10 +127,14 @@ disp:
 
   coordinate_transformation: FACT
   # columns containing coordinates of the source and of the pointing
-  source_azimuth_column: source_position_az
   source_zenith_column: source_position_zd
+  source_zenith_unit: rad
+  source_azimuth_column: source_position_az
+  source_azimuth_unit: rad 
   pointing_azimuth_column: pointing_position_az
+  pointing_azimuth_unit: rad
   pointing_zenith_column: pointing_position_zd
+  pointing_zenith_unit: rad
 
   # randomly sample the data if you dont want to use the whole set
   n_signal : 500

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,7 @@ def test_full():
     c = AICTConfig.from_yaml('examples/full_config.yaml')
 
     assert c.energy is not None
+    assert c.energy_unit is not None
     assert c.disp is not None
     assert c.separator is not None
 


### PR DESCRIPTION
Allows to set units for the columns:

- pointing_az/zd
- source_az/zd
- delta

These can be set in the DISP config. Defaults are "deg" for all az/zd columns and "rad" for delta.

!! This will break the CTA analyses, because the explicit deg2rad(delta) is gone!!
Your will need to specify the unit as "deg" as is done in the `examples/config_source_cta.yaml`.


Further ideas:
- Do we need units for focal length and camera coordinates (mm/m)?
- Do we want to specify the unit of the Energy (GeV/TeV)? If so: Would this be a global option?
- Are there any other columns that we need to watch out for?



ToDo:
- [x] add units for the angles and transform values
- [x] add unit for the focal length and transform values
- [x] add unit for the energy and use it for plotting labels
- [x] add tests for the DISP results -> not needed for now
- [x] add tests for the plot scripts -> #129 